### PR TITLE
Make IR size and register select values configurable

### DIFF
--- a/approved/config_test/workout_jtag_dp.atp
+++ b/approved/config_test/workout_jtag_dp.atp
@@ -1,0 +1,699 @@
+// ***************************************************************************
+// GENERATED:
+//   Time:    08-Feb-2018 15:55PM
+//   By:      nxa18793
+//   Command: origen g pattern/workout.rb -t config_test.rb -e j750.rb
+// ***************************************************************************
+// ENVIRONMENT:
+//   Application
+//     Source:    git@github.com:Origen-SDK/origen_arm_debug.git
+//     Version:   1.0.2
+//     Branch:    IRsize(15908a2cecf) (+local edits)
+//   Origen
+//     Source:    https://github.com/Origen-SDK/origen
+//     Version:   0.25.1
+//   Plugins
+//     atp:                      0.5.4
+//     origen_doc_helpers:       0.5.0
+//     origen_jtag:              0.17.0
+//     origen_swd:               1.1.0
+//     origen_testers:           0.9.9
+// ***************************************************************************
+import tset arm_debug;                                                                          
+import svm_subr write_overlay_subr;                                                             
+import svm_subr read_overlay_subr;                                                              
+svm_only_file = no;                                                                             
+opcode_mode = extended;                                                                         
+compressed = yes;                                                                               
+                                                                                                
+vector ($tset, tclk, tdi, tdo, tms, trst, swd_clk, swd_dio)                                     
+{                                                                                               
+start_label pattern_st:                                                                         
+//                                                                                              t t t t t s s
+//                                                                                              c d d m r w w
+//                                                                                              l i o s s d d
+//                                                                                              k       t - -
+//                                                                                                        c d
+//                                                                                                        l i
+//                                                                                                        k o
+// ######################################################################
+// ## Tests of direct DP API
+// ######################################################################
+// [ARM Debug] Read JTAG-DP register IDCODE: 0xX0012XXX
+repeat 6                                                         > arm_debug                    0 X X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 X X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 X X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 X X 0 X X X ;
+// [JTAG] Write IR: 0xFE
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 6                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFE
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0xX0012XXX
+repeat 12                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+repeat 11                                                        > arm_debug                    0 0 L 0 X X X ;
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Read DR: 0xX0012XXX
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read JTAG-DP register IDCODE: 0xX0012XXX
+// [ARM Debug] Write JTAG-DP register CTRLSTAT: 0x50000000
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x280000002
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 29                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x280000002
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write JTAG-DP register CTRLSTAT: 0x50000000
+// [ARM Debug] Read JTAG-DP register CTRLSTAT: 0xF0000000
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x3
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 32                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x3
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Read DR: 0x78000000_0xxx
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+repeat 28                                                        > arm_debug                    0 0 L 0 X X X ;
+repeat 3                                                         > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 1 X X X ;
+// [JTAG] /Read DR: 0x78000000_0xxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read JTAG-DP register CTRLSTAT: 0xF0000000
+// [ARM Debug] Write JTAG-DP register SELECT: 0xF0
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x784
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 23                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x784
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write JTAG-DP register SELECT: 0xF0
+// [ARM Debug] Write JTAG-DP register ABORT: 0x1
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xF8
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xF8
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x8
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 30                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x8
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write JTAG-DP register ABORT: 0x1
+// ######################################################################
+// ## Tests of direct AP API
+// ######################################################################
+// [ARM Debug] Write MEM-AP (mem_ap) register TAR: 0x12340000
+// [ARM Debug] Write JTAG-DP register SELECT: 0x0
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x4
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 31                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x4
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write JTAG-DP register SELECT: 0x0
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFB
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFB
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x91A00002
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 19                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x91A00002
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 9                                                         > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) register TAR: 0x12340000
+// [ARM Debug] Read MEM-AP (mem_ap) register TAR: 0x12340000
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x3
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 32                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x3
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 9                                                         > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0x091A0000_0xxx
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+repeat 18                                                        > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 H 0 X X X ;
+repeat 3                                                         > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 1 X X X ;
+// [JTAG] /Read DR: 0x091A0000_0xxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read MEM-AP (mem_ap) register TAR: 0x12340000
+// ######################################################################
+// ## Tests of high-level register API
+// ######################################################################
+// ######################################################################
+// ## Test write register, should write value 0xFF01
+// ######################################################################
+// [ARM Debug] Write MEM-AP (mem_ap) address 0x0: 0xFF01
+// [ARM Debug] Write MEM-AP (mem_ap) register CSW: 0x23000042
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFB
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFB
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x118000210
+repeat 4                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 17                                                        > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x118000210
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 9                                                         > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) register CSW: 0x23000042
+// [ARM Debug] Write MEM-AP (mem_ap) register TAR: 0x0
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x2
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+repeat 32                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x2
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 9                                                         > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) register TAR: 0x0
+// [ARM Debug] Write MEM-AP (mem_ap) register DRW: 0xFF01
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x7F80E
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 3                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 7                                                         > arm_debug                    0 0 X 0 X X X ;
+repeat 8                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 15                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7F80E
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 9                                                         > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) register DRW: 0xFF01
+repeat 16                                                        > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) address 0x0: 0xFF01
+// ######################################################################
+// ## Test write register with overlay, no subroutine
+// ######################################################################
+// [ARM Debug] Write MEM-AP (mem_ap) address 0x0: 0xFF01
+// [ARM Debug] Write MEM-AP (mem_ap) register DRW: 0xFF01
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x7F80E
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+write_overlay:                                                                                  
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7F80E
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 9                                                         > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) register DRW: 0xFF01
+repeat 16                                                        > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) address 0x0: 0xFF01
+// ######################################################################
+// ## Test write register with overlay, use subroutine if available
+// ######################################################################
+// [ARM Debug] Write MEM-AP (mem_ap) address 0x0: 0xFF01
+// [ARM Debug] Write MEM-AP (mem_ap) register DRW: 0xFF01
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x7F80E
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+call write_overlay_subr                                          > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] /Write DR: 0x7F80E
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 9                                                         > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) register DRW: 0xFF01
+repeat 16                                                        > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Write MEM-AP (mem_ap) address 0x0: 0xFF01
+// ######################################################################
+// ## Test read register, should read value 0x0000FF01
+// ######################################################################
+// [ARM Debug] Read MEM-AP (mem_ap) address 0x0: 0x0000FF01
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write DR: 0x7
+repeat 3                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 31                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 17                                                        > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0x00007F80_1xxx
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+repeat 7                                                         > arm_debug                    0 0 L 0 X X X ;
+repeat 8                                                         > arm_debug                    0 0 H 0 X X X ;
+repeat 15                                                        > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 1 X X X ;
+// [JTAG] /Read DR: 0x00007F80_1xxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read MEM-AP (mem_ap) address 0x0: 0x0000FF01
+// ######################################################################
+// ## Test read register, with overlay, no subroutine, should read value 0x0000FF01
+// ######################################################################
+// [ARM Debug] Read MEM-AP (mem_ap) address 0x0: 0xVVVVVVVV
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFB
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFB
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x7
+repeat 3                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 31                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 17                                                        > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0xVVVVVVVV_vxxx
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+read_overlay:                                                                                   
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 0 X X X ;
+                                                                 > arm_debug                    0 0 L 1 X X X ;
+// [JTAG] /Read DR: 0xVVVVVVVV_vxxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read MEM-AP (mem_ap) address 0x0: 0xVVVVVVVV
+// ######################################################################
+// ## Test read register, with overlay, use subroutine if available
+// ######################################################################
+// [ARM Debug] Read MEM-AP (mem_ap) address 0x0: 0xVVVVVVVV
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFB
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFB
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x7
+repeat 3                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 31                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 17                                                        > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0xVVVVVVVV_vxxx
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+call read_overlay_subr                                           > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] /Read DR: 0xVVVVVVVV_vxxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read MEM-AP (mem_ap) address 0x0: 0xVVVVVVVV
+// ######################################################################
+// ## Test read register with mask, should read value 0xXXXxxx1
+// ######################################################################
+// [ARM Debug] Read MEM-AP (mem_ap) address 0x0: 0xXXXXXXX1
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFB
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFB
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x7
+repeat 3                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 31                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 17                                                        > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0xXXXXXXX_x000_1xxx
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+repeat 3                                                         > arm_debug                    0 0 L 0 X X X ;
+repeat 27                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Read DR: 0xXXXXXXX_x000_1xxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read MEM-AP (mem_ap) address 0x0: 0xXXXXXXX1
+// ######################################################################
+// ## Test read register with store
+// ######################################################################
+// [ARM Debug] Read MEM-AP (mem_ap) address 0x0: 0xSSSSSSSS
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFB
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFB
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x7
+repeat 3                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 31                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 17                                                        > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0xSSSSSSSS_sxxx
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 0 X X X ;
+stv                                                              > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Read DR: 0xSSSSSSSS_sxxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read MEM-AP (mem_ap) address 0x0: 0xSSSSSSSS
+// ######################################################################
+// ## Test bit level read, should read value 0xXXXxxx1
+// ######################################################################
+// [ARM Debug] Read MEM-AP (mem_ap) address 0x0: 0xXXXXXXX_xxx1
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFB
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFB
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Write DR: 0x7
+repeat 3                                                         > arm_debug                    0 1 X 0 X X X ;
+repeat 31                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Write DR: 0x7
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+repeat 17                                                        > arm_debug                    0 0 X 0 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 0 X 0 X X X ;
+// [JTAG] Write IR: 0xFA
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+repeat 4                                                         > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+// [JTAG] /Write IR: 0xFA
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+                                                                 > arm_debug                    0 1 X 0 X X X ;
+                                                                 > arm_debug                    0 1 X 1 X X X ;
+repeat 2                                                         > arm_debug                    0 1 X 0 X X X ;
+// [JTAG] Read DR: 0xXXXXXXXX_1xxx
+repeat 3                                                         > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 H 0 X X X ;
+repeat 30                                                        > arm_debug                    0 0 X 0 X X X ;
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+// [JTAG] /Read DR: 0xXXXXXXXX_1xxx
+                                                                 > arm_debug                    0 0 X 1 X X X ;
+                                                                 > arm_debug                    0 0 X 0 X X X ;
+// [ARM Debug] /Read MEM-AP (mem_ap) address 0x0: 0xXXXXXXX_xxx1
+// ######################################################################
+// ## Pattern complete
+// ######################################################################
+end_module                                                       > arm_debug                    0 0 X 0 X X X ;
+}                                                                                               

--- a/config/commands.rb
+++ b/config/commands.rb
@@ -30,6 +30,8 @@ when "examples"    # , "test"
   load "#{Origen.top}/lib/origen/commands/generate.rb"
   ARGV = %w(workout -t swd -e j750 -r approved)
   load "#{Origen.top}/lib/origen/commands/generate.rb"
+  ARGV = %w(workout -t config_test -e j750 -r approved/config_test)
+  load "#{Origen.top}/lib/origen/commands/generate.rb"
     
   if Origen.app.stats.changed_files == 0 &&
      Origen.app.stats.new_files == 0 &&

--- a/lib/origen_arm_debug/dap.rb
+++ b/lib/origen_arm_debug/dap.rb
@@ -20,7 +20,8 @@ module OrigenARMDebug
       end
 
       if options[:jtag] || parent.respond_to?(:jtag)
-        dps << sub_block(:jtag_dp, class_name: 'JTAG_DP')
+        options[:class_name] = 'JTAG_DP'
+        dps << sub_block(:jtag_dp, options)
       end
 
       Array(options[:mem_aps]).each do |name, base_address|

--- a/lib/origen_arm_debug/jtag_dp.rb
+++ b/lib/origen_arm_debug/jtag_dp.rb
@@ -2,8 +2,19 @@ module OrigenARMDebug
   class JTAG_DP
     include Origen::Model
 
+    attr_reader :dpacc_select, :apacc_select
+
     def initialize(options = {})
-      add_reg :ir, 0, size: 4
+      options = {
+        ir_size:       4,
+        idcode_select: 0b1110,
+        abort_select:  0b1000,
+        dpacc_select:  0b1010,
+        apacc_select:  0b1011
+      }.merge(options)
+      @dpacc_select = options[:dpacc_select]
+      @apacc_select = options[:apacc_select]
+      add_reg :ir, 0, size: options[:ir_size]
 
       # Virtual reg used to represent all of the various 35-bit scan chains
       reg :dr, 0, size: 35 do |reg|
@@ -12,7 +23,7 @@ module OrigenARMDebug
         reg.bit 0, :rnw
       end
 
-      reg :idcode, 0b1110, access: :ro do |reg|
+      reg :idcode, options[:idcode_select], access: :ro do |reg|
         reg.bit 31..28, :version
         reg.bit 27..12, :partno
         reg.bit 11..1, :designer
@@ -42,7 +53,7 @@ module OrigenARMDebug
 
       add_reg :rdbuff, 0xC, access: :ro, reset: 0
 
-      reg :abort, 0b1000, access: :wo do |reg|
+      reg :abort, options[:abort_select], access: :wo do |reg|
         reg.bit 0, :dapabort
       end
     end

--- a/lib/origen_arm_debug/jtag_dp_controller.rb
+++ b/lib/origen_arm_debug/jtag_dp_controller.rb
@@ -33,7 +33,7 @@ module OrigenARMDebug
               dr[0].write(0)
               dr[2..1].write(reg.offset >> 2)
               dr[34..3].copy_all(reg)
-              ir.write!(0b1010)
+              ir.write!(dpacc_select)
               dut.jtag.write_dr(dr)
 
             else
@@ -55,7 +55,7 @@ module OrigenARMDebug
         dr[0].write(0)
         dr[2..1].write(reg.offset >> 2)
         dr[34..3].copy_all(reg)
-        ir.write!(0b1011)
+        ir.write!(apacc_select)
         dut.jtag.write_dr(dr, options)
       end
     end
@@ -86,7 +86,7 @@ module OrigenARMDebug
               dr[0].write(1)
               dr[2..1].write(reg.offset >> 2)
               dr[34..3].write(0)
-              ir.write!(0b1010)
+              ir.write!(dpacc_select)
               dut.jtag.write_dr(dr)
 
               # Part 2 - Now read real data from RDBUFF (DP-Reg)
@@ -117,7 +117,7 @@ module OrigenARMDebug
         dr[0].write(1)
         dr[2..1].write(reg.offset >> 2)
         dr[34..3].write(0)
-        ir.write!(0b1011)
+        ir.write!(apacc_select)
         dut.jtag.write_dr(dr)
 
         # Calling AP should provide any delay parameter for wait states between AP read request
@@ -133,7 +133,7 @@ module OrigenARMDebug
         dr[2..1].write(rdbuff.offset >> 2)
         dr[34..3].copy_all(reg)
         options[:mask] = options[:mask] << 3 unless options[:mask].nil?
-        ir.write!(0b1010)
+        ir.write!(dpacc_select)
         dut.jtag.read_dr(dr, options)
       end
     end

--- a/lib/origen_arm_debug_dev/dut.rb
+++ b/lib/origen_arm_debug_dev/dut.rb
@@ -13,7 +13,7 @@ module OrigenARMDebugDev
     # @example
     #   $dut = OrigenARMDebugDev::DUT.new
     #
-    def initialize
+    def initialize(options = {})
       add_reg :test, 0
 
       reg :test2, 0 do |reg|

--- a/lib/origen_arm_debug_dev/dut_jtag.rb
+++ b/lib/origen_arm_debug_dev/dut_jtag.rb
@@ -5,7 +5,7 @@ module OrigenARMDebugDev
 
     # Adds jtag-required pins to the simple dut model
     # Returns nothing.
-    def initialize
+    def initialize(options = {})
       super
       add_pin :tclk
       add_pin :tdi
@@ -15,18 +15,19 @@ module OrigenARMDebugDev
       add_pin :swd_clk
       add_pin :swd_dio
 
+      options[:class_name] = 'OrigenARMDebug::DAP'
+      options[:mem_aps] = {
+        mem_ap: {
+          base_address:      0x00000000,
+          latency:           16,
+          apreg_access_wait: 8,
+          apmem_access_wait: 8,
+          csw_reset:         0x23000040
+        },
+        mdm_ap: 0x01000000
+      }
       # Specify (customize) ARM Debug implementation details
-      sub_block :arm_debug, class_name: 'OrigenARMDebug::DAP',
-                            mem_aps:    {
-                              mem_ap: {
-                                base_address:      0x00000000,
-                                latency:           16,
-                                apreg_access_wait: 8,
-                                apmem_access_wait: 8,
-                                csw_reset:         0x23000040
-                              },
-                              mdm_ap: 0x01000000
-                            }
+      sub_block :arm_debug, options
     end
   end
 end

--- a/target/config_test.rb
+++ b/target/config_test.rb
@@ -1,0 +1,2 @@
+OrigenARMDebugDev::JTAG_DUT.new(ir_size: 8, idcode_select: 0xFE, abort_select: 0xF8, dpacc_select: 0xFA, apacc_select: 0xFB)
+Origen.mode = :debug

--- a/templates/web/index.md.erb
+++ b/templates/web/index.md.erb
@@ -28,11 +28,10 @@ if your app is a plugin.
 
 ### How To Use
 
-Include the <code>OrigenARMDebug</code> module in your DUT class, then hook it up
-to the Origen register API via
+The most common way to use the Arm Debugger plugin is through the Origen register API via
 <code>read_register</code> and <code>write_register</code> methods.
 
-You must also include a compatible physical driver depending on what debug
+You must include a compatible physical driver depending on what debug
 interface your device has, one of the following can be used:
 
 * [JTAG](http://origen-sdk.org/jtag)
@@ -41,9 +40,8 @@ interface your device has, one of the following can be used:
 ~~~ruby
 class DUT
   include Origen::TopLevel
-  include OrigenARMDebug
 
-  # Also include the required physical driver, JTAG in this example
+  # Include the required physical driver, JTAG in this example
   include OrigenJTAG
 
   def initialize
@@ -55,7 +53,11 @@ class DUT
     # Simple example using default wait-states and latency:
     #   mem_ap:  APSEL = 0x00 (base_address[31:24])
     #   mem2_ap: APSEL = 0x01 (base_address[31:24])
-    sub_block :arm_debug, class_name: 'OrigenARMDebug::DAP', mem_aps: { mem_ap: 0x00000000, mem2_ap: 0x01000000 }                           
+    mem_aps = {
+      mem_ap: { base_address: 0x00000000 }
+      mem2_ap: { base_address: 0x10000000 }
+    }
+    sub_block :arm_debug, class_name: 'OrigenARMDebug::DAP', mem_aps: mem_aps                           
   end
 
   # Hook the ARMDebug module into the register API, any register read
@@ -97,6 +99,41 @@ You can also adjust the intermediate wait-states and latency parameters:
 dut.arm_debug.ahb_ap.apmem_access_wait = 16
 dut.arm_debug.ahb_ap.apreg_access_wait = 12
 dut.arm_debug.ahb_ap.latency = 8
+
+# You can define these at instantiation as well
+mem_aps = {
+  mem_ap: { base_address: 0x00000000, latency: 8, apreg_access_wait: 12, apmem_access_wait: 16 }
+  mem2_ap: { base_address: 0x10000000, latency: 8, apreg_access_wait: 12, apmem_access_wait: 16 }
+}
+sub_block :arm_debug, class_name: 'OrigenARMDebug::DAP', mem_aps: mem_aps
+~~~
+
+When used with the JTAG physical driver these are the default IR size 4 and the default register select values are:
+
+~~~
+idcode_select = 0b1110
+abort_select  = 0b1000
+dpacc_select  = 0b1010
+apacc_select  = 0b1011
+~~~
+
+You can set non-default values at instantiation like this:
+
+~~~ruby
+mem_aps = {
+  mem_ap: { base_address: 0x00000000 }
+  mem2_ap: { base_address: 0x10000000 }
+}
+instantiation_options[:class_name] = 'OrigenARMDebug::DAP'
+instantiation_options[:mem_aps] = mem_aps
+
+instantiation_options[:ir_size] = 8
+instantiation_options[:idcode_select] = 0xFE
+instantiation_options[:abort_select] = 0xF8
+instantiation_options[:dpacc_select] = 0xFA
+instantiation_options[:apacc_select] = 0xFB
+
+sub_block :arm_debug, instantiation_options
 ~~~
 
 ### Company Customization

--- a/templates/web/index.md.erb
+++ b/templates/web/index.md.erb
@@ -108,7 +108,7 @@ mem_aps = {
 sub_block :arm_debug, class_name: 'OrigenARMDebug::DAP', mem_aps: mem_aps
 ~~~
 
-When used with the JTAG physical driver these are the default IR size 4 and the default register select values are:
+When used with the JTAG physical driver the default IR size is 4 and the default register select values are:
 
 ~~~
 idcode_select = 0b1110


### PR DESCRIPTION
This PR is to add the ability to make the top level tap size configurable (instead of fixed at 4 bits) and the register select for IDCODE, APACC, DPACC and ABORT configurable.  The original configuration is maintained as the default configuration.