### PR TITLE
Add support for apacc_wait_states to SWD

### DIFF
--- a/lib/origen_arm_debug/mem_ap.rb
+++ b/lib/origen_arm_debug/mem_ap.rb
@@ -8,7 +8,7 @@ module OrigenARMDebug
     #   read request.  Should be added to apreg_access_wait for complete transaction
     #   time of memory read (read data path: memory->drw->rdbuff)
     attr_accessor :apmem_access_wait
-    
+
     # Wait states to occur in between configuring the DAP for a read, and for the the read transaction to begin.
     #   For JTAG, this is the wait states in between setting the AP and for the read transaction to occur.
     #   For SWD, this is the wait states in between setting the AP, initiating and completing a dummy read, and beginning the actual read transaction.

--- a/lib/origen_arm_debug/mem_ap.rb
+++ b/lib/origen_arm_debug/mem_ap.rb
@@ -8,6 +8,11 @@ module OrigenARMDebug
     #   read request.  Should be added to apreg_access_wait for complete transaction
     #   time of memory read (read data path: memory->drw->rdbuff)
     attr_accessor :apmem_access_wait
+    
+    # Wait states to occur in between configuring the DAP for a read, and for the the read transaction to begin.
+    #   For JTAG, this is the wait states in between setting the AP and for the read transaction to occur.
+    #   For SWD, this is the wait states in between setting the AP, initiating and completing a dummy read, and beginning the actual read transaction.
+    attr_accessor :apacc_wait_states
 
     def initialize(options = {})
       super

--- a/lib/origen_arm_debug/sw_dp_controller.rb
+++ b/lib/origen_arm_debug/sw_dp_controller.rb
@@ -39,6 +39,13 @@ module OrigenARMDebug
 
         select_ap_reg(reg)
         dut.swd.read_ap(address: reg.address)
+        
+        # Add any extra delay needed in between selecting the AP state, initiating and completing a dummy read, and
+        # starting the actual read.
+        if options[:apacc_wait_states]
+          options[:apacc_wait_states].cycles
+        end
+        
         dut.swd.read_dp(reg, options.merge(address: rdbuff.address))
       end
     end

--- a/lib/origen_arm_debug/sw_dp_controller.rb
+++ b/lib/origen_arm_debug/sw_dp_controller.rb
@@ -39,13 +39,13 @@ module OrigenARMDebug
 
         select_ap_reg(reg)
         dut.swd.read_ap(address: reg.address)
-        
+
         # Add any extra delay needed in between selecting the AP state, initiating and completing a dummy read, and
         # starting the actual read.
         if options[:apacc_wait_states]
           options[:apacc_wait_states].cycles
         end
-        
+
         dut.swd.read_dp(reg, options.merge(address: rdbuff.address))
       end
     end

--- a/templates/web/index.md.erb
+++ b/templates/web/index.md.erb
@@ -90,9 +90,10 @@ arm_debug.ahb_ap.csw.write!(0x23000052)
 
 You can also adjust the intermediate wait-states and latency parameters:
 
-* [AP.apreg_access_wait](http://origen-sdk.org/arm_debug/api/OrigenARMDebug/AP.html#apreg_access_wait-instance_method)
-* [MemAP.apmem_access_wait](http://origen-sdk.org/arm_debug/api/OrigenARMDebug/MemAP.html#apmem_access_wait-instance_method)
-* [MemAP.latency](http://origen-sdk.org/arm_debug/api/OrigenARMDebug/MemAP.html#latency-instance_method)
+* [AP.apreg_access_wait](<%= path '/api/OrigenARMDebug/AP.html#apreg_access_wait-instance_method' %>)
+* [MemAP.apmem_access_wait](<%= path '/api/OrigenARMDebug/MemAP.html#apmem_access_wait-instance_method' %>)
+* [MemAP.latency](<%= path '/api/OrigenARMDebug/MemAP.html#latency-instance_method' %>)
+* [MemAP.apacc_wait_states](<%= path '/api/OrigenARMDebug/MemAP.html#apacc_wait_states-instance_method' %>)
 
 ~~~ruby
 # Assuming ahb_ap has been previously defined


### PR DESCRIPTION
Added apacc_wait_states for SWD. Required if swdclk is running faster than the platform clock. Updated the docs and added an accessor so it appears in the API.