### PR TITLE
write 0 to tar instead of tar.reset.  

### DIFF
--- a/lib/origen_arm_debug/mem_ap_controller.rb
+++ b/lib/origen_arm_debug/mem_ap_controller.rb
@@ -74,7 +74,7 @@ module OrigenARMDebug
 
       # Reset tar if just crossed a 1kB boundary
       if address_increment_enabled? && (tar[9..0].data == 0)
-        tar.reset
+        tar.write(0)
       end
     end
   end


### PR DESCRIPTION
tar.reset does not work for the way the register is defined (needs to be fixed at some point) and this mimics what really happens at 1K boundary anyway.  without this, the SWD auto-increment boundary logic does not work.